### PR TITLE
Use hostPath instead of emptyDir for WLAPI socket

### DIFF
--- a/example/config/spire-agent.yaml
+++ b/example/config/spire-agent.yaml
@@ -179,10 +179,17 @@ spec:
               path: spire-agent
               expirationSeconds: 7200
               audience: spire-server
-        # This volume is used to share the workload api socket between the
-        # CSI driver and SPIRE agent
+        # This volume is used to share the Workload API socket between the CSI
+        # driver and SPIRE agent. Note, an emptyDir volume could also be used,
+        # however, this can lead to broken bind mounts in the workload
+        # containers if the agent pod is restarted (since the emptyDir
+        # directory on the node that was mounted into workload containers by
+        # the CSI driver belongs to the old pod instance and is no longer
+        # valid).
         - name: spire-agent-socket-dir
-          emptyDir: {}
+          hostPath:
+            path: /run/spire/agent-sockets
+            type: DirectoryOrCreate
         # This volume is where the socket for kubelet->driver communication lives
         - name: spiffe-csi-socket-dir
           hostPath:

--- a/test/config/spiffe-csi-driver.yaml
+++ b/test/config/spiffe-csi-driver.yaml
@@ -12,7 +12,7 @@ spec:
   podInfoOnMount: true
 
   # We don't want (or need) K8s to change ownership on the contents of the mount
-  # when it is moutned into the pod, since the Workload API is completely open
+  # when it is mounted into the pod, since the Workload API is completely open
   # (i.e. 0777).
   # Note, this was added in Kubernetes 1.19, so omit
   fsGroupPolicy: None

--- a/test/config/spire-agent.yaml
+++ b/test/config/spire-agent.yaml
@@ -179,10 +179,12 @@ spec:
               path: spire-agent
               expirationSeconds: 7200
               audience: spire-server
-        # This volume is used to share the workload api socket between the
+        # This volume is used to share the Workload API socket between the
         # CSI driver and SPIRE agent
         - name: spire-agent-socket-dir
-          emptyDir: {}
+          hostPath:
+            path: /run/spire/agent-sockets
+            type: DirectoryOrCreate
         # This volume is where the socket for kubelet->driver communication lives
         - name: spiffe-csi-socket-dir
           hostPath:


### PR DESCRIPTION
Signed-off-by: Andrew Harding <aharding@vmware.com>