### PR TITLE
Return rudimentary volume health status

### DIFF
--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -88,7 +88,24 @@ func TestBoilerplateRPCs(t *testing.T) {
 	t.Run("NodeGetCapabilities", func(t *testing.T) {
 		resp, err := client.NodeGetCapabilities(context.Background(), &csi.NodeGetCapabilitiesRequest{})
 		require.NoError(t, err)
-		requireProtoEqual(t, &csi.NodeGetCapabilitiesResponse{}, resp, "unexpected response")
+		requireProtoEqual(t, &csi.NodeGetCapabilitiesResponse{
+			Capabilities: []*csi.NodeServiceCapability{
+				{
+					Type: &csi.NodeServiceCapability_Rpc{
+						Rpc: &csi.NodeServiceCapability_RPC{
+							Type: csi.NodeServiceCapability_RPC_VOLUME_CONDITION,
+						},
+					},
+				},
+				{
+					Type: &csi.NodeServiceCapability_Rpc{
+						Rpc: &csi.NodeServiceCapability_RPC{
+							Type: csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
+						},
+					},
+				},
+			},
+		}, resp, "unexpected response")
 	})
 
 	t.Run("NodeGetInfo", func(t *testing.T) {

--- a/pkg/logkeys/keys.go
+++ b/pkg/logkeys/keys.go
@@ -7,5 +7,6 @@ const (
 	TargetPath           = "targetPath"
 	Version              = "version"
 	VolumeID             = "volumeID"
+	VolumePath           = "volumePath"
 	WorkloadAPISocketDir = "workloadAPISocketDir"
 )

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -1,11 +1,16 @@
 package mount
 
-// BindMountRO performs a read-only bind mount from src to dest
-func BindMountRO(src, dst string) error {
-	return bindMountRO(src, dst)
+// BindMountRO performs a read-only bind mount from root to mountPoint
+func BindMountRO(root, mountPoint string) error {
+	return bindMountRO(root, mountPoint)
 }
 
 // Unmount unmounts a mount
-func Unmount(path string) error {
-	return unmount(path)
+func Unmount(mountPoint string) error {
+	return unmount(mountPoint)
+}
+
+// IsMountPoint returns whether or not the given mount point is valid.
+func IsMountPoint(mountPoint string) (bool, error) {
+	return isMountPoint(mountPoint)
 }

--- a/pkg/mount/mount_linux.go
+++ b/pkg/mount/mount_linux.go
@@ -1,16 +1,101 @@
 package mount
 
-import "golang.org/x/sys/unix"
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
 
 const (
 	msRdOnly uintptr = 1    // LINUX MS_RDONLY
 	msBind   uintptr = 4096 // LINUX MS_BIND
 )
 
-func bindMountRO(src, dst string) error {
-	return unix.Mount(src, dst, "none", msBind|msRdOnly, "")
+var (
+	// procMountInfo is the path the mount information presented by the proc
+	// filesystem for the current process. It is overriden in unit tests to
+	// test the parsing.
+	procMountInfo = "/proc/self/mountinfo"
+)
+
+func bindMountRO(root, mountPoint string) error {
+	return unix.Mount(root, mountPoint, "none", msBind|msRdOnly, "")
 }
 
-func unmount(path string) error {
-	return unix.Unmount(path, 0)
+func unmount(mountPoint string) error {
+	return unix.Unmount(mountPoint, 0)
+}
+
+func isMountPoint(mountPoint string) (bool, error) {
+	mounts, err := enumerateMounts()
+	if err != nil {
+		return false, fmt.Errorf("failed to enumerate bind mounts: %w", err)
+	}
+	for _, mount := range mounts {
+		if mount.MountPoint == mountPoint {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func enumerateMounts() ([]mountInfo, error) {
+	f, err := os.Open(procMountInfo)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open mount info: %w", err)
+	}
+	defer f.Close()
+
+	var mounts []mountInfo
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		mount, err := parseMountInfo(scanner.Text())
+		if err != nil {
+			continue
+		}
+		mounts = append(mounts, mount)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to scan mount info: %w", err)
+	}
+	return mounts, nil
+}
+
+type mountInfo struct {
+	MountID    string
+	ParentID   string
+	DevID      string
+	Root       string
+	MountPoint string
+}
+
+func parseMountInfo(line string) (mountInfo, error) {
+	const minColumns = 5
+	fields := strings.Fields(line)
+	if len(fields) < minColumns {
+		return mountInfo{}, fmt.Errorf("mount info does not have at least %d columns", minColumns)
+	}
+
+	return mountInfo{
+		MountID:    fields[0],
+		ParentID:   fields[1],
+		DevID:      fields[2],
+		Root:       unescapeOctal(fields[3]),
+		MountPoint: unescapeOctal(fields[4]),
+	}, nil
+}
+
+var reOctal = regexp.MustCompile(`\\([0-7]{3})`)
+
+func unescapeOctal(s string) string {
+	return reOctal.ReplaceAllStringFunc(s, func(oct string) string {
+		// cannot fail due to regex constraints
+		r, _ := strconv.ParseUint(oct[1:], 8, 64)
+		return string(rune(r))
+	})
 }

--- a/pkg/mount/mount_linux.go
+++ b/pkg/mount/mount_linux.go
@@ -18,7 +18,7 @@ const (
 
 var (
 	// procMountInfo is the path the mount information presented by the proc
-	// filesystem for the current process. It is overriden in unit tests to
+	// filesystem for the current process. It is overridden in unit tests to
 	// test the parsing.
 	procMountInfo = "/proc/self/mountinfo"
 )

--- a/pkg/mount/mount_linux_test.go
+++ b/pkg/mount/mount_linux_test.go
@@ -1,0 +1,24 @@
+package mount
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	procMountInfo = "testdata/mountinfo"
+}
+
+func TestIsMountPoint(t *testing.T) {
+	const mountPoint = "/var/lib/kubelet/pods/c3a32fc0-f186-4974-8579-429dea58ec6d/volumes/kubernetes.io~csi/spire-agent-socket/mount"
+
+	ok, err := IsMountPoint(mountPoint)
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = IsMountPoint(mountPoint + "other")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}

--- a/pkg/mount/mount_other.go
+++ b/pkg/mount/mount_other.go
@@ -14,3 +14,7 @@ func bindMountRO(src, dst string) error {
 func unmount(path string) error {
 	return errors.New("unsupported on this platform")
 }
+
+func isMountPoint(mountPoint string) (bool, error) {
+	return false, errors.New("unsupported on this platform")
+}

--- a/pkg/mount/testdata/mountinfo
+++ b/pkg/mount/testdata/mountinfo
@@ -1,0 +1,28 @@
+1276 805 0:283 / / rw,relatime - overlay overlay rw,lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/152/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/63/fs,upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/182/fs,workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/182/work
+1277 1276 0:285 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
+1278 1276 0:291 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+1279 1278 0:292 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+1280 1278 0:255 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw
+1281 1276 0:149 / /sys rw,nosuid,nodev,noexec,relatime - sysfs sysfs ro
+1282 1281 0:30 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw
+1283 1276 254:1 /docker/volumes/ae14d1dc9612d7d30d542a76b17f1a4df12a2167161454111652d5b863be332c/_data/spire-agent-socket-dir /spire-agent-socket ro,relatime - ext4 /dev/vda1 rw
+1291 1276 254:1 /docker/volumes/ae14d1dc9612d7d30d542a76b17f1a4df12a2167161454111652d5b863be332c/_data/lib/kubelet/plugins/csi.spiffe.io /spiffe-csi rw,relatime - ext4 /dev/vda1 rw
+1292 1278 0:251 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,size=65536k
+1293 1276 254:1 /docker/volumes/ae14d1dc9612d7d30d542a76b17f1a4df12a2167161454111652d5b863be332c/_data/lib/kubelet/pods/ba1f3cb7-6de1-4e68-90c3-a17b49c609de/etc-hosts /etc/hosts rw,relatime - ext4 /dev/vda1 rw
+1294 1278 254:1 /docker/volumes/ae14d1dc9612d7d30d542a76b17f1a4df12a2167161454111652d5b863be332c/_data/lib/kubelet/pods/ba1f3cb7-6de1-4e68-90c3-a17b49c609de/containers/spiffe-csi-driver/6d7a662e /dev/termination-log rw,relatime - ext4 /dev/vda1 rw
+1295 1276 254:1 /docker/volumes/ae14d1dc9612d7d30d542a76b17f1a4df12a2167161454111652d5b863be332c/_data/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/817b61a8b634da271000f1bf70e2147c4584a4e8fe8161e5904b900c0a8c8588/hostname /etc/hostname rw,relatime - ext4 /dev/vda1 rw
+1296 1276 254:1 /docker/volumes/ae14d1dc9612d7d30d542a76b17f1a4df12a2167161454111652d5b863be332c/_data/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/817b61a8b634da271000f1bf70e2147c4584a4e8fe8161e5904b900c0a8c8588/resolv.conf /etc/resolv.conf rw,relatime - ext4 /dev/vda1 rw
+1297 1276 254:1 /docker/volumes/ae14d1dc9612d7d30d542a76b17f1a4df12a2167161454111652d5b863be332c/_data/lib/kubelet/pods /var/lib/kubelet/pods rw,relatime shared:195 master:28 - ext4 /dev/vda1 rw
+1298 1297 0:252 / /var/lib/kubelet/pods/f29021da-ea07-4828-adec-cd70cb9435f6/volumes/kubernetes.io~projected/kube-api-access-p4vl5 rw,relatime shared:229 - tmpfs tmpfs rw
+1299 1297 0:258 / /var/lib/kubelet/pods/8d5455fe-90e2-43b2-b9b4-fc6a79f1745f/volumes/kubernetes.io~projected/kube-api-access-cdcnf rw,relatime shared:232 - tmpfs tmpfs rw
+1300 1297 0:295 / /var/lib/kubelet/pods/d1fc398a-15ab-4109-817a-601a4b7932a2/volumes/kubernetes.io~projected/kube-api-access-gbk8v rw,relatime shared:240 - tmpfs tmpfs rw
+1301 1297 0:314 / /var/lib/kubelet/pods/7cc4af94-fd10-4ad4-b17e-46cb7b1f3fc8/volumes/kubernetes.io~projected/kube-api-access-lzlz9 rw,relatime shared:244 - tmpfs tmpfs rw
+1302 1297 0:338 / /var/lib/kubelet/pods/85e8c8e6-c4ad-4dd3-b820-06520b58367b/volumes/kubernetes.io~projected/kube-api-access-pjpfr rw,relatime shared:251 - tmpfs tmpfs rw
+1303 1297 0:223 / /var/lib/kubelet/pods/5a888803-bf74-4958-ba18-a1c08cac1d24/volumes/kubernetes.io~projected/kube-api-access-vcwdd rw,relatime shared:219 - tmpfs tmpfs rw
+1304 1297 0:237 / /var/lib/kubelet/pods/c3a32fc0-f186-4974-8579-429dea58ec6d/volumes/kubernetes.io~projected/kube-api-access-56mpv rw,relatime shared:224 - tmpfs tmpfs rw
+1305 1297 0:248 / /var/lib/kubelet/pods/72e3589e-908c-476f-9f95-2b1884552d1c/volumes/kubernetes.io~projected/kube-api-access-9vsww rw,relatime shared:225 - tmpfs tmpfs rw
+1306 1297 254:1 /docker/volumes/ae14d1dc9612d7d30d542a76b17f1a4df12a2167161454111652d5b863be332c/_data/spire-agent-socket-dir /var/lib/kubelet/pods/c3a32fc0-f186-4974-8579-429dea58ec6d/volumes/kubernetes.io~csi/spire-agent-socket/mount ro,relatime shared:257 - ext4 /dev/vda1 rw
+1307 1297 254:1 /docker/volumes/ae14d1dc9612d7d30d542a76b17f1a4df12a2167161454111652d5b863be332c/_data/spire-agent-socket-dir /var/lib/kubelet/pods/72e3589e-908c-476f-9f95-2b1884552d1c/volumes/kubernetes.io~csi/spire-agent-socket/mount ro,relatime shared:258 - ext4 /dev/vda1 rw
+1308 1297 0:249 / /var/lib/kubelet/pods/ba1f3cb7-6de1-4e68-90c3-a17b49c609de/volumes/kubernetes.io~projected/spire-token rw,relatime shared:227 - tmpfs tmpfs rw
+1309 1297 0:250 / /var/lib/kubelet/pods/ba1f3cb7-6de1-4e68-90c3-a17b49c609de/volumes/kubernetes.io~projected/kube-api-access-mkgzr rw,relatime shared:228 - tmpfs tmpfs rw
+1310 1276 0:250 / /run/secrets/kubernetes.io/serviceaccount ro,relatime - tmpfs tmpfs rw

--- a/test/config/cluster.yaml
+++ b/test/config/cluster.yaml
@@ -1,0 +1,4 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  "CSIVolumeHealth": true

--- a/test/run.sh
+++ b/test/run.sh
@@ -66,7 +66,7 @@ download-kind() {
 
 create-cluster() {
     echo "Creating cluster..."
-    "${KIND}" create cluster
+    "${KIND}" create cluster --config "${DIR}/config/cluster.yaml"
     echo "Cluster created."
 }
 


### PR DESCRIPTION
Ensures that previously published volume paths are still mounted and
that we can enumerate the contents (if any).

Does not do any further validation at this point.

Signed-off-by: Andrew Harding <aharding@vmware.com>