### PR TITLE
Enforce read-only volumes

### DIFF
--- a/cmd/spiffe-csi-driver/main.go
+++ b/cmd/spiffe-csi-driver/main.go
@@ -15,11 +15,10 @@ import (
 )
 
 var (
-	enforceReadOnlyVolumeFlag = flag.Bool("enforce-read-only-volume", false, "If set, enforce that the CSI volume is marked read-only")
-	nodeIDFlag                = flag.String("node-id", "", "Kubernetes Node ID. If unset, the node ID is obtained from the environment (i.e., -node-id-env)")
-	nodeIDEnvFlag             = flag.String("node-id-env", "MY_NODE_NAME", "Envvar from which to obtain the node ID. Overridden by -node-id.")
-	csiSocketPathFlag         = flag.String("csi-socket-path", "/spiffe-csi/csi.sock", "Path to the CSI socket")
-	workloadAPISocketDirFlag  = flag.String("workload-api-socket-dir", "", "Path to the Workload API socket directory")
+	nodeIDFlag               = flag.String("node-id", "", "Kubernetes Node ID. If unset, the node ID is obtained from the environment (i.e., -node-id-env)")
+	nodeIDEnvFlag            = flag.String("node-id-env", "MY_NODE_NAME", "Envvar from which to obtain the node ID. Overridden by -node-id.")
+	csiSocketPathFlag        = flag.String("csi-socket-path", "/spiffe-csi/csi.sock", "Path to the CSI socket")
+	workloadAPISocketDirFlag = flag.String("workload-api-socket-dir", "", "Path to the Workload API socket directory")
 )
 
 func main() {
@@ -40,18 +39,6 @@ func main() {
 	}
 	log = zapr.NewLogger(zapLog)
 
-	// If the enforce-read-only-volume flag was not explicitly provided,
-	// instruct the user to set it. Either way, if it is set to false, or
-	// unset, emit a log educating users that the will be enforced in the
-	// future.
-	// TODO: enforce this by default in a future release.
-	if !isFlagSet("enforce-read-only-volume") {
-		log.Error(nil, "Pass the --enforce-read-only-volume flag to enforce that the CSI volume is marked read-only")
-	}
-	if !*enforceReadOnlyVolumeFlag {
-		log.Error(nil, "Not enforcing that the CSI volume is marked read-only; this will be required in a future release")
-	}
-
 	nodeID := getNodeIDFromFlags()
 
 	log.Info("Starting.",
@@ -59,7 +46,6 @@ func main() {
 		logkeys.NodeID, nodeID,
 		logkeys.WorkloadAPISocketDir, *workloadAPISocketDirFlag,
 		logkeys.CSISocketPath, *csiSocketPathFlag,
-		logkeys.EnforceReadOnlyVolume, *enforceReadOnlyVolumeFlag,
 	)
 
 	driver, err := driver.New(driver.Config{
@@ -91,14 +77,4 @@ func getNodeIDFromFlags() string {
 		nodeID = *nodeIDFlag
 	}
 	return nodeID
-}
-
-func isFlagSet(name string) bool {
-	set := false
-	flag.Visit(func(f *flag.Flag) {
-		if f.Name == name {
-			set = true
-		}
-	})
-	return set
 }

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -21,7 +21,6 @@ const (
 
 var (
 	// We replace these in tests since bind mounting generally requires root.
-	bindMountRO  = mount.BindMountRO
 	bindMountRW  = mount.BindMountRW
 	unmount      = mount.Unmount
 	isMountPoint = mount.IsMountPoint
@@ -29,10 +28,9 @@ var (
 
 // Config is the configuration for the driver
 type Config struct {
-	Log                   logr.Logger
-	NodeID                string
-	WorkloadAPISocketDir  string
-	EnforceReadOnlyVolume bool
+	Log                  logr.Logger
+	NodeID               string
+	WorkloadAPISocketDir string
 }
 
 // Driver is the ephemeral-inline CSI driver implementation
@@ -40,10 +38,9 @@ type Driver struct {
 	csi.UnimplementedIdentityServer
 	csi.UnimplementedNodeServer
 
-	log                   logr.Logger
-	nodeID                string
-	workloadAPISocketDir  string
-	enforceReadOnlyVolume bool
+	log                  logr.Logger
+	nodeID               string
+	workloadAPISocketDir string
 }
 
 // New creates a new driver with the given config
@@ -55,10 +52,9 @@ func New(config Config) (*Driver, error) {
 		return nil, errors.New("workload API socket directory is required")
 	}
 	return &Driver{
-		log:                   config.Log,
-		nodeID:                config.NodeID,
-		workloadAPISocketDir:  config.WorkloadAPISocketDir,
-		enforceReadOnlyVolume: config.EnforceReadOnlyVolume,
+		log:                  config.Log,
+		nodeID:               config.NodeID,
+		workloadAPISocketDir: config.WorkloadAPISocketDir,
 	}, nil
 }
 
@@ -119,7 +115,7 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		return nil, status.Error(codes.InvalidArgument, "request missing required volume capability access mode")
 	case isVolumeCapabilityAccessModeReadOnly(req.VolumeCapability.AccessMode):
 		return nil, status.Error(codes.InvalidArgument, "request volume capability access mode is not valid")
-	case d.enforceReadOnlyVolume && !req.Readonly:
+	case !req.Readonly:
 		return nil, status.Error(codes.InvalidArgument, "pod.spec.volumes[].csi.readOnly must be set to 'true'")
 	case ephemeralMode != "true":
 		return nil, status.Error(codes.InvalidArgument, "only ephemeral volumes are supported")
@@ -132,22 +128,11 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 
 	// Ideally the volume is writable by the host to enable, for example,
 	// manipulation of file attributes by SELinux. However, the volume MUST NOT
-	// be writable by workload containers.
-	//
-	// Therefore, if the volume is marked read-only, thus ensuring that the
-	// kubelet will mount it read-only into the workload container, bind mount
-	// the agent socket directory read-write to the target path on the host.
-	//
-	// If the volume is not marked read-only, then do a read-only mount to
-	// prevent the directory from being manipulated by the workload container.
-	if req.Readonly {
-		if err := bindMountRW(d.workloadAPISocketDir, req.TargetPath); err != nil {
-			return nil, status.Errorf(codes.Internal, "unable to mount %q read-write: %v", req.TargetPath, err)
-		}
-	} else {
-		if err := bindMountRO(d.workloadAPISocketDir, req.TargetPath); err != nil {
-			return nil, status.Errorf(codes.Internal, "unable to mount %q read-only: %v", req.TargetPath, err)
-		}
+	// be writable by workload containers. We enforce that the CSI volume is
+	// marked read-only above, instructing the kubelet to mount it read-only
+	// into containers, while we mount the volume read-write to the host.
+	if err := bindMountRW(d.workloadAPISocketDir, req.TargetPath); err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to mount %q: %v", req.TargetPath, err)
 	}
 
 	log.Info("Volume published")

--- a/pkg/logkeys/keys.go
+++ b/pkg/logkeys/keys.go
@@ -1,13 +1,12 @@
 package logkeys
 
 const (
-	CSISocketPath         = "csiSocketPath"
-	EnforceReadOnlyVolume = "enforceReadOnlyVolume"
-	FullMethod            = "fullMethod"
-	NodeID                = "nodeID"
-	TargetPath            = "targetPath"
-	Version               = "version"
-	VolumeID              = "volumeID"
-	VolumePath            = "volumePath"
-	WorkloadAPISocketDir  = "workloadAPISocketDir"
+	CSISocketPath        = "csiSocketPath"
+	FullMethod           = "fullMethod"
+	NodeID               = "nodeID"
+	TargetPath           = "targetPath"
+	Version              = "version"
+	VolumeID             = "volumeID"
+	VolumePath           = "volumePath"
+	WorkloadAPISocketDir = "workloadAPISocketDir"
 )

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -1,10 +1,5 @@
 package mount
 
-// BindMountRO performs a read-only bind mount from root to mountPoint
-func BindMountRO(root, mountPoint string) error {
-	return bindMountRO(root, mountPoint)
-}
-
 // BindMountRW performs a read-write bind mount from root to mountPoint
 func BindMountRW(root, mountPoint string) error {
 	return bindMountRW(root, mountPoint)

--- a/pkg/mount/mount_linux.go
+++ b/pkg/mount/mount_linux.go
@@ -12,8 +12,7 @@ import (
 )
 
 const (
-	msRdOnly uintptr = 1    // LINUX MS_RDONLY
-	msBind   uintptr = 4096 // LINUX MS_BIND
+	msBind uintptr = 4096 // LINUX MS_BIND
 )
 
 var (
@@ -22,10 +21,6 @@ var (
 	// test the parsing.
 	procMountInfo = "/proc/self/mountinfo"
 )
-
-func bindMountRO(root, mountPoint string) error {
-	return unix.Mount(root, mountPoint, "none", msBind|msRdOnly, "")
-}
 
 func bindMountRW(root, mountPoint string) error {
 	return unix.Mount(root, mountPoint, "none", msBind, "")

--- a/test/config/spiffe-csi-test-workload-1.yaml
+++ b/test/config/spiffe-csi-test-workload-1.yaml
@@ -31,6 +31,4 @@ spec:
       - name: spire-agent-socket
         csi:
           driver: "csi.spiffe.io"
-          # Don't set the readOnly attribute since we need to ensure existing
-          # deployments work.
-          # TODO: set readOnly once we enforce it
+          readOnly: true


### PR DESCRIPTION
After further consideration, the warning logs and flag for backcompat feel a little ineffective. The logs are not a very actionable place to do deprecation warnings. They are just tucked away too deep for anyone to notice.

Further, since this will be the only change between 0.1.0 and 0.2.0, if enforcement is problematic, operators can just not upgrade (or downgrade if they don't read the changelog before upgrading).