### PR TITLE
Fix push images on forks

### DIFF
--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -7,6 +7,9 @@ on:
 jobs:
   build-and-publish-images:
     runs-on: ubuntu-22.04
+    permissions:
+      packages: write
+      
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -66,7 +66,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [validate, integration-test]
-
+    permissions:
+      packages: write
+      
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/scripts/push-images.sh
+++ b/.github/workflows/scripts/push-images.sh
@@ -36,8 +36,13 @@ fi
 
 echo "Pushing image tagged as ${version}..."
 
-LOCALIMG=ghcr.io/spiffe/spiffe-csi-driver:devel
-REMOTEIMG=ghcr.io/spiffe/spiffe-csi-driver:"${version}"
+image=spiffe-csi-driver
+org_name=$(echo "$GITHUB_REPOSITORY" | tr '/' "\n" | head -1 | tr -d "\n")
+org_name="${org_name:-spiffe}" # default to spiffe in case ran outside of GitHub actions
+registry=ghcr.io/${org_name}
+
+LOCALIMG=ghcr.io/spiffe/${image}:devel
+REMOTEIMG="${registry}/${image}:${version}"
 
 echo "Executing: docker tag $LOCALIMG $REMOTEIMG"
 docker tag "$LOCALIMG" "$REMOTEIMG"


### PR DESCRIPTION
This resolves the failing nightly at my fork. https://github.com/marcofranssen/spiffe-csi/actions

Also rebased #70 on top of this change.