### PR TITLE
Update deploy-spire-and-csi-driver.sh

### DIFF
--- a/example/deploy-spire-and-csi-driver.sh
+++ b/example/deploy-spire-and-csi-driver.sh
@@ -4,11 +4,11 @@ set -e -o pipefail
 
 DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-echo "Applying SPIFFE CSI Driver configuration..."
-kubectl apply -f "$DIR"/config/spiffe-csi-driver.yaml
-
 echo "Creating SPIRE namespace..."
 kubectl apply -f "$DIR"/config/spire-namespace.yaml
+
+echo "Applying SPIFFE CSI Driver configuration..."
+kubectl apply -f "$DIR"/config/spiffe-csi-driver.yaml
 
 echo "Deploying SPIRE server"
 kubectl apply -f "$DIR"/config/spire-server.yaml


### PR DESCRIPTION
Moved the namespace creation to before the spiffe-csi-driver creation, because the csi driver service account requires the spire namespace to exist.