### PR TITLE
Make plugin name configurable

### DIFF
--- a/cmd/spiffe-csi-driver/main.go
+++ b/cmd/spiffe-csi-driver/main.go
@@ -18,6 +18,7 @@ var (
 	nodeIDFlag               = flag.String("node-id", "", "Kubernetes Node ID. If unset, the node ID is obtained from the environment (i.e., -node-id-env)")
 	nodeIDEnvFlag            = flag.String("node-id-env", "MY_NODE_NAME", "Envvar from which to obtain the node ID. Overridden by -node-id.")
 	csiSocketPathFlag        = flag.String("csi-socket-path", "/spiffe-csi/csi.sock", "Path to the CSI socket")
+	pluginNameFlag           = flag.String("plugin-name", "csi.spiffe.io", "Plugin name to register")
 	workloadAPISocketDirFlag = flag.String("workload-api-socket-dir", "", "Path to the Workload API socket directory")
 )
 
@@ -51,6 +52,7 @@ func main() {
 	driver, err := driver.New(driver.Config{
 		Log:                  log,
 		NodeID:               nodeID,
+		PluginName:           *pluginNameFlag,
 		WorkloadAPISocketDir: *workloadAPISocketDirFlag,
 	})
 	if err != nil {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -15,10 +15,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const (
-	pluginName = "csi.spiffe.io"
-)
-
 var (
 	// We replace these in tests since bind mounting generally requires root.
 	bindMountRW  = mount.BindMountRW
@@ -30,6 +26,7 @@ var (
 type Config struct {
 	Log                  logr.Logger
 	NodeID               string
+	PluginName           string
 	WorkloadAPISocketDir string
 }
 
@@ -40,6 +37,7 @@ type Driver struct {
 
 	log                  logr.Logger
 	nodeID               string
+	pluginName           string
 	workloadAPISocketDir string
 }
 
@@ -54,6 +52,7 @@ func New(config Config) (*Driver, error) {
 	return &Driver{
 		log:                  config.Log,
 		nodeID:               config.NodeID,
+		pluginName:           config.PluginName,
 		workloadAPISocketDir: config.WorkloadAPISocketDir,
 	}, nil
 }
@@ -64,7 +63,7 @@ func New(config Config) (*Driver, error) {
 
 func (d *Driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
 	return &csi.GetPluginInfoResponse{
-		Name:          pluginName,
+		Name:          d.pluginName,
 		VendorVersion: version.Version(),
 	}, nil
 }

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -408,6 +408,7 @@ func startDriver(t *testing.T) (client, string) {
 	d, err := New(Config{
 		Log:                  logr.Discard(),
 		NodeID:               testNodeID,
+		PluginName:           "csi.spiffe.io",
 		WorkloadAPISocketDir: workloadAPISocketDir,
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
When deploying federated, you may need multiple instances of the csidriver. This patch enables the needed options.