### PR TITLE
Add PVC for spire-server in spiffe-csi example

### DIFF
--- a/example/config/spire-server.yaml
+++ b/example/config/spire-server.yaml
@@ -156,6 +156,22 @@ data:
 
 ---
 
+# PersistentVolumeClaim for spire-server data store
+# needed to persist registrations over pod restarts
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: spire-server-pvc
+  namespace: spire
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100M
+
+---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -187,10 +203,15 @@ spec:
             - name: spire-config
               mountPath: /run/spire/config
               readOnly: true
+            - name: spire-data
+              mountPath: /run/spire/data
       volumes:
         - name: spire-config
           configMap:
             name: spire-server
+        - name: spire-data
+          persistentVolumeClaim:
+            claimName: spire-server-pvc
 
 ---
 


### PR DESCRIPTION
Added a PVC to the spire-server deployment in order to persist the spire server data store (especially node and workload registrations) across pod restarts. This would fail if the target cluster does not have a default storage class, and we could handle that with some logic in the deploy-spire-and-csi-driver.sh script, but in the majority of cases, storage will be available, and certainly the spire-server needs persistent storage in any real-world use case. So I think it's fair to expect a PVC creation to succeed, for this example.