### PR TITLE
Bump example versions to latest releases

### DIFF
--- a/example/config/spiffe-csi-driver.yaml
+++ b/example/config/spiffe-csi-driver.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         # This is the container which runs the SPIFFE CSI driver.
         - name: spiffe-csi-driver
-          image: ghcr.io/spiffe/spiffe-csi-driver:0.2.0
+          image: ghcr.io/spiffe/spiffe-csi-driver:0.2.3
           imagePullPolicy: IfNotPresent
           args: [
             "-workload-api-socket-dir", "/spire-agent-socket",

--- a/example/config/spire-agent.yaml
+++ b/example/config/spire-agent.yaml
@@ -102,7 +102,7 @@ spec:
       serviceAccountName: spire-agent
       containers:
         - name: spire-agent
-          image: ghcr.io/spiffe/spire-agent:1.1.1
+          image: ghcr.io/spiffe/spire-agent:1.8.0
           imagePullPolicy: IfNotPresent
           args: ["-config", "/run/spire/config/agent.conf"]
           volumeMounts:

--- a/example/config/spire-server.yaml
+++ b/example/config/spire-server.yaml
@@ -105,7 +105,6 @@ data:
       trust_domain = "example.org"
       data_dir = "/run/spire/data"
       log_level = "DEBUG"
-      default_svid_ttl = "1h"
       ca_ttl = "12h"
       ca_subject {
         country = ["US"]
@@ -178,7 +177,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: spire-server
-          image: ghcr.io/spiffe/spire-server:1.1.1
+          image: ghcr.io/spiffe/spire-server:1.8.0
           imagePullPolicy: IfNotPresent
           args: ["-config", "/run/spire/config/server.conf"]
           ports:


### PR DESCRIPTION
Bump spiffe-csi-driver image version from 0.2.0 to 0.2.3
Bump spire-server and spire-agent images from 1.1.1 to 1.8.0
Remove default_svid_ttl config parameter from spire server config because it is no longer supported and has been replaced by different parameters for x509 and jwt, which both have sensible default values, so no need to include them for the example.