### PR TITLE
fix: update from go vsn 1.24.0 to 1.24.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the SPIFFE CSI Driver binary
-FROM --platform=${BUILDPLATFORM} golang:1.24.0-alpine AS base
+FROM --platform=${BUILDPLATFORM} golang:1.24.6-alpine AS base
 WORKDIR /code
 RUN apk --no-cache --update add make
 COPY go.* ./

--- a/example/workload/Dockerfile
+++ b/example/workload/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.0-alpine
+FROM golang:1.24.6-alpine
 
 WORKDIR /app
 

--- a/example/workload/go.mod
+++ b/example/workload/go.mod
@@ -2,6 +2,8 @@ module workload
 
 go 1.24.0
 
+toolchain go1.24.6
+
 require github.com/spiffe/go-spiffe/v2 v2.5.0
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/spiffe/spiffe-csi
 
 go 1.24.0
 
+toolchain go1.24.6
+
 require (
 	github.com/container-storage-interface/spec v1.11.0
 	github.com/go-logr/logr v1.4.3

--- a/test/workload/Dockerfile
+++ b/test/workload/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.0-alpine
+FROM golang:1.24.6-alpine
 
 WORKDIR /app
 

--- a/test/workload/go.mod
+++ b/test/workload/go.mod
@@ -2,6 +2,8 @@ module workload
 
 go 1.24.0
 
+toolchain go1.24.6
+
 require github.com/spiffe/go-spiffe/v2 v2.5.0
 
 require (


### PR DESCRIPTION
go 1.24 has some vulnerabilities, including:

- CVE-2025-22871
- CVE-2025-22874
- CVE-2025-4674 
- CVE-2025-0913
- CVE-2025-4673

this pr remediates those by upgrading to go 1.24.6, and gives a clean grype scan of the built image
```
➜  spiffe-csi git:(main) grype ghcr.io/spiffe/spiffe-csi-driver:devel            
 ✔ Loaded image                                                         ghcr.io/spiffe/spiffe-csi-driver:devel 
 ✔ Parsed image                        sha256:193744e3760201d437e19ccb219a8ee06549462b00970a6f9b99688fda4f735f 
 ✔ Cataloged contents                         1b5ab636ec108f8aea3b4d1d7175be6374573ab74d80c3717a296bba54e3743f 
   ├── ✔ Packages                        [12 packages]  
   ├── ✔ Executables                     [1 executables]  
   ├── ✔ File digests                    [1 files]  
   └── ✔ File metadata                   [1 locations]  
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]  
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored 
```
