### PR TITLE
perf(mount): scan mountinfo once and early-exit on first match

### DIFF
--- a/pkg/mount/mount_linux.go
+++ b/pkg/mount/mount_linux.go
@@ -3,6 +3,7 @@ package mount
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"strconv"
@@ -22,6 +23,10 @@ var (
 	procMountInfo = "/proc/self/mountinfo"
 )
 
+// mountPointIdx is the slice index of the mount point in a parsed mountinfo
+// record. proc(5) "/proc/[pid]/mountinfo" documents it as field 5.
+const mountPointIdx = 4
+
 func bindMountRW(root, mountPoint string) error {
 	return unix.Mount(root, mountPoint, "none", msBind, "")
 }
@@ -31,62 +36,34 @@ func unmount(mountPoint string) error {
 }
 
 func isMountPoint(mountPoint string) (bool, error) {
-	mounts, err := enumerateMounts()
+	f, err := os.Open(procMountInfo)
 	if err != nil {
-		return false, fmt.Errorf("failed to enumerate bind mounts: %w", err)
+		return false, fmt.Errorf("unable to open mount info: %w", err)
 	}
-	for _, mount := range mounts {
-		if mount.MountPoint == mountPoint {
+	defer func() { _ = f.Close() }()
+	return isMountPointInReader(f, mountPoint)
+}
+
+// isMountPointInReader scans mountinfo-formatted records from r and reports
+// whether any record's mount point (field 5) equals mountPoint. It returns on
+// the first match so the per-call working set is independent of the host's
+// total mount count.
+func isMountPointInReader(r io.Reader, mountPoint string) (bool, error) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) <= mountPointIdx {
+			continue
+		}
+		if unescapeOctal(fields[mountPointIdx]) == mountPoint {
 			return true, nil
 		}
 	}
-	return false, nil
-}
-
-func enumerateMounts() ([]mountInfo, error) {
-	f, err := os.Open(procMountInfo)
-	if err != nil {
-		return nil, fmt.Errorf("unable to open mount info: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	var mounts []mountInfo
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		mount, err := parseMountInfo(scanner.Text())
-		if err != nil {
-			continue
-		}
-		mounts = append(mounts, mount)
-	}
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("failed to scan mount info: %w", err)
+		return false, fmt.Errorf("failed to scan mount info: %w", err)
 	}
-	return mounts, nil
-}
-
-type mountInfo struct {
-	MountID    string
-	ParentID   string
-	DevID      string
-	Root       string
-	MountPoint string
-}
-
-func parseMountInfo(line string) (mountInfo, error) {
-	const minColumns = 5
-	fields := strings.Fields(line)
-	if len(fields) < minColumns {
-		return mountInfo{}, fmt.Errorf("mount info does not have at least %d columns", minColumns)
-	}
-
-	return mountInfo{
-		MountID:    fields[0],
-		ParentID:   fields[1],
-		DevID:      fields[2],
-		Root:       unescapeOctal(fields[3]),
-		MountPoint: unescapeOctal(fields[4]),
-	}, nil
+	return false, nil
 }
 
 var reOctal = regexp.MustCompile(`\\([0-7]{3})`)

--- a/pkg/mount/mount_linux_test.go
+++ b/pkg/mount/mount_linux_test.go
@@ -1,6 +1,9 @@
 package mount
 
 import (
+	"fmt"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,4 +24,92 @@ func TestIsMountPoint(t *testing.T) {
 	ok, err = IsMountPoint(mountPoint + "other")
 	require.NoError(t, err)
 	assert.False(t, ok)
+}
+
+// TestIsMountPointInReader_OctalEscape verifies that mount points containing
+// whitespace match against their octal-escaped representation in mountinfo
+// (e.g. "/mnt/has space" appears as "/mnt/has\040space" in field 5).
+func TestIsMountPointInReader_OctalEscape(t *testing.T) {
+	tests := []struct {
+		name      string
+		line      string
+		target    string
+		wantMatch bool
+	}{
+		{
+			name:      "single space",
+			line:      `36 35 0:0 / /mnt/has\040space rw,relatime - tmpfs tmpfs rw`,
+			target:    "/mnt/has space",
+			wantMatch: true,
+		},
+		{
+			name:      "non-consecutive spaces",
+			line:      `36 35 0:0 / /mnt/a\040b\040c rw,relatime - tmpfs tmpfs rw`,
+			target:    "/mnt/a b c",
+			wantMatch: true,
+		},
+		{
+			name:      "consecutive spaces",
+			line:      `36 35 0:0 / /mnt/double\040\040space rw,relatime - tmpfs tmpfs rw`,
+			target:    "/mnt/double  space",
+			wantMatch: true,
+		},
+		{
+			name:      "raw escaped form does not match",
+			line:      `36 35 0:0 / /mnt/has\040space rw,relatime - tmpfs tmpfs rw`,
+			target:    `/mnt/has\040space`,
+			wantMatch: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := isMountPointInReader(strings.NewReader(tt.line+"\n"), tt.target)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMatch, got)
+		})
+	}
+}
+
+func BenchmarkIsMountPoint(b *testing.B) {
+	const total = 10_000
+	const target = "/var/lib/kubelet/pods/pod-target/volumes/kubernetes.io~csi/spiffe/mount"
+
+	cases := []struct {
+		name      string
+		targetIdx int // -1 means no line in the input matches.
+	}{
+		{"FirstMatch", 0},
+		{"LastMatch", total - 1},
+		{"NoMatch", -1},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			f, err := os.CreateTemp(b.TempDir(), "mountinfo")
+			require.NoError(b, err)
+			for i := 0; i < total; i++ {
+				mp := fmt.Sprintf(
+					"/var/lib/kubelet/pods/pod-%d/volumes/kubernetes.io~csi/spiffe/mount",
+					i,
+				)
+				if i == tc.targetIdx {
+					mp = target
+				}
+				_, err := fmt.Fprintf(f, "%d %d 0:%d / %s rw,relatime - tmpfs tmpfs rw\n",
+					1000+i, 999, 100+i, mp)
+				require.NoError(b, err)
+			}
+			require.NoError(b, f.Close())
+
+			orig := procMountInfo
+			procMountInfo = f.Name()
+			b.Cleanup(func() { procMountInfo = orig })
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				_, _ = IsMountPoint(target)
+			}
+		})
+	}
 }


### PR DESCRIPTION

## Summary

`isMountPoint` currently reads all of `/proc/self/mountinfo` into a `[]mountInfo` slice via `enumerateMounts`, then linear-searches for the target path. Per-call peak working set therefore grows linearly with the host's total mount count, even though the function only needs to know whether one specific path appears anywhere in the file.

The function is hot. Kubelet calls it (via `NodeGetVolumeStats` / `checkWorkloadAPIMount`) periodically per CSI volume, and the driver also calls it from `NodeUnpublishVolume` on every pod termination. On nodes with many CSI-using pods the cumulative allocation pressure is large enough to be visible at the cgroup level. I noticed this during load-testing on a kind cluster: at 200 dummy replicas mounting a `csi.spiffe.io` volume, the driver's `VmHWM` peaked at ~52 MiB despite a steady-state RSS below 10 MiB.

## Change

Refactors `isMountPoint` to scan `/proc/self/mountinfo` line-by-line and return on the first match, dropping the `[]mountInfo` accumulator. Per-call working set becomes independent of the host's total mount count. Octal-escape handling on the matched field is preserved; a 1 MiB scanner buffer cap and propagated `scanner.Err()` ensure any pathologically long line fails loudly. A table-driven test locks in the escape behaviour.

## Benchmark

10,000-line synthetic mountinfo, varying the position of the target line. Run via `go test -bench=BenchmarkIsMountPoint -benchmem -benchtime=3s ./pkg/mount/`. The benchmark function is identical on both branches; the baseline column was produced from a worktree at `main` (commit `946eccd`) with the same benchmark function patched in.

| Position    | Baseline                            | This PR                             | Speedup |
|-------------|-------------------------------------|-------------------------------------|---------|
| First match | 4.89 ms / 8.55 MB / 70,040 allocs   | **15.1 us / 66.8 KB / 9 allocs**    | 323x    |
| Last match  | 4.93 ms / 8.55 MB / 70,040 allocs   | 2.33 ms / 4.75 MB / 50,013 allocs   | 2.1x    |
| No match    | 5.26 ms / 8.55 MB / 70,040 allocs   | 2.42 ms / 4.75 MB / 50,013 allocs   | 2.2x    |

