### PR TITLE
Upgrade cosign and fix nightly

### DIFF
--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -14,16 +14,13 @@ jobs:
       id-token: write
       packages: write
 
-    env:
-      COSIGN_EXPERIMENTAL: 1
-
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v3.5.2
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
-          cosign-release: v2.2.3
+          cosign-release: v2.6.3
       - name: Install regctl
         uses: regclient/actions/regctl-installer@f3c6d87835906c175eb6ccfc18b348b69bb447e7 # main
       - name: Build images

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -93,16 +93,13 @@ jobs:
       id-token: write
       packages: write
 
-    env:
-      COSIGN_EXPERIMENTAL: 1
-
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
-          cosign-release: v2.6.2
+          cosign-release: v2.6.3
       - name: Install regctl
         uses: regclient/actions/regctl-installer@f3c6d87835906c175eb6ccfc18b348b69bb447e7 # main
       - name: Download archived images


### PR DESCRIPTION
Nightly has been failing for a while because it didn't get the same cosign upgrade. This moves to the latest 2.x cosign version for both nightly and release flows. COSIGN_EXPERIMENTAL hasn't been needed for quite a while, so dropping that too.