### PR TITLE
Add an isMountPoint check before bindMountRW to return early

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -130,6 +130,14 @@ func (d *Driver) NodePublishVolume(_ context.Context, req *csi.NodePublishVolume
 		return nil, status.Errorf(codes.Internal, "unable to create target path %q: %v", req.TargetPath, err)
 	}
 
+	// Return if the target path is already mounted
+	if mounted, mountErr := isMountPoint(req.TargetPath); mountErr != nil {
+		return nil, status.Errorf(codes.Internal, "unable to verify mount point %q: %v", req.TargetPath, mountErr)
+	} else if mounted {
+		log.Info("Volume already published")
+		return &csi.NodePublishVolumeResponse{}, nil
+	}
+
 	// Ideally the volume is writable by the host to enable, for example,
 	// manipulation of file attributes by SELinux. However, the volume MUST NOT
 	// be writable by workload containers. We enforce that the CSI volume is

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -42,7 +42,7 @@ func init() {
 	unmount = func(dst string) error {
 		return os.Remove(metaPath(dst))
 	}
-	isMountPoint = func(string) (bool, error) {
+	isMountPoint = func(path string) (bool, error) {
 		if testDescription == unmountFailureTest {
 			return true, nil
 		}
@@ -51,7 +51,9 @@ func init() {
 			return false, fmt.Errorf("mock invalid mount point")
 		}
 
-		return true, nil
+		// Check if the meta file exists to simulate a real mount check.
+		_, err := os.Stat(metaPath(path))
+		return err == nil, nil
 	}
 }
 
@@ -313,6 +315,52 @@ func TestNodePublishVolume(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNodePublishVolumeIdempotent(t *testing.T) {
+	// calling NodePublishVolume twice on the same target path
+	// must not create duplicate mounts.
+	originalBindMountRW := bindMountRW
+	mountCalls := 0
+	bindMountRW = func(src, dst string) error {
+		mountCalls++
+		return originalBindMountRW(src, dst)
+	}
+	t.Cleanup(func() {
+		bindMountRW = originalBindMountRW
+	})
+
+	client, workloadAPISocketDir := startDriver(t)
+
+	targetPathBase := t.TempDir()
+	targetPath := filepath.Join(targetPathBase, "target-path")
+
+	req := &csi.NodePublishVolumeRequest{
+		VolumeId:   "volumeID",
+		TargetPath: targetPath,
+		Readonly:   true,
+		VolumeCapability: &csi.VolumeCapability{
+			AccessType: &csi.VolumeCapability_Mount{},
+			AccessMode: &csi.VolumeCapability_AccessMode{},
+		},
+		VolumeContext: map[string]string{
+			"csi.storage.k8s.io/ephemeral": "true",
+		},
+	}
+
+	// First call: should mount
+	resp, err := client.NodePublishVolume(context.Background(), req)
+	require.NoError(t, err)
+	assertProtoEqual(t, &csi.NodePublishVolumeResponse{}, resp)
+	assertMounted(t, targetPath, workloadAPISocketDir)
+	assert.Equal(t, 1, mountCalls, "first publish should mount once")
+
+	// Second call should succeed without re-mounting
+	resp, err = client.NodePublishVolume(context.Background(), req)
+	require.NoError(t, err)
+	assertProtoEqual(t, &csi.NodePublishVolumeResponse{}, resp)
+	assertMounted(t, targetPath, workloadAPISocketDir)
+	assert.Equal(t, 1, mountCalls, "second publish should not re-mount")
 }
 
 func TestNodeUnpublishVolume(t *testing.T) {


### PR DESCRIPTION
closes #331 

## Summary

This change makes NodePublishVolume return success when the target path is already mounted instead of bind-mounting the workload API socket a second time. That keeps the node plugin aligned with CSI idempotency requirements and avoids duplicate mount accumulation during kubelet reconciliation or restart.

## Change

- `pkg/driver/driver.go` adds an early `isMountPoint` check in NodePublishVolume and returns OK when the target path is already published.
- `pkg/driver/driver_test.go` updates the fake mountpoint behavior to reflect mount state via the test meta file and adds TestNodePublishVolumeIdempotent which calls NodePublishVolume twice on the same target and asserts the mount hook only runs once.

## Testing
- Unit tests pass
- Tested the behavior in kind cluster