### PR TITLE
Update Go to 1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the SPIFFE CSI Driver binary
-FROM --platform=${BUILDPLATFORM} golang:1.26.2-alpine AS base
+FROM --platform=${BUILDPLATFORM} golang:1.26.4-alpine AS base
 WORKDIR /code
 RUN apk --no-cache --update add make
 COPY go.* ./

--- a/example/workload/Dockerfile
+++ b/example/workload/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-alpine
+FROM golang:1.26.4-alpine
 
 WORKDIR /app
 

--- a/example/workload/go.mod
+++ b/example/workload/go.mod
@@ -1,6 +1,6 @@
 module workload
 
-go 1.26.2
+go 1.26.4
 
 require github.com/spiffe/go-spiffe/v2 v2.6.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spiffe/spiffe-csi
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/container-storage-interface/spec v1.12.0

--- a/test/workload/Dockerfile
+++ b/test/workload/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-alpine
+FROM golang:1.26.4-alpine
 
 WORKDIR /app
 

--- a/test/workload/go.mod
+++ b/test/workload/go.mod
@@ -1,6 +1,6 @@
 module workload
 
-go 1.26.2
+go 1.26.4
 
 require github.com/spiffe/go-spiffe/v2 v2.6.0
 


### PR DESCRIPTION
Supersedes #335, which bumped only the main build Dockerfile. This updates the pinned Go version to 1.26.4 in every place it appears in the repo:

- Dockerfile (driver build image)
- example/workload/Dockerfile and example/workload/go.mod
- test/workload/Dockerfile and test/workload/go.mod
- go.mod (root module directive)
