### PR TITLE
Add recursive mount support

### DIFF
--- a/cmd/spiffe-csi-driver/main.go
+++ b/cmd/spiffe-csi-driver/main.go
@@ -21,6 +21,7 @@ var (
 	csiSocketPathFlag        = flag.String("csi-socket-path", "/spiffe-csi/csi.sock", "Path to the CSI socket")
 	pluginNameFlag           = flag.String("plugin-name", "csi.spiffe.io", "Plugin name to register")
 	workloadAPISocketDirFlag = flag.String("workload-api-socket-dir", "", "Path to the Workload API socket directory")
+	recursiveBindFlag        = flag.Bool("recursive-bind", false, "Also publish anything mounted beneath the Workload API socket directory")
 )
 
 func main() {
@@ -48,6 +49,7 @@ func main() {
 		logkeys.NodeID, nodeID,
 		logkeys.WorkloadAPISocketDir, *workloadAPISocketDirFlag,
 		logkeys.CSISocketPath, *csiSocketPathFlag,
+		logkeys.RecursiveBind, *recursiveBindFlag,
 	)
 
 	driver, err := driver.New(driver.Config{
@@ -55,6 +57,7 @@ func main() {
 		NodeID:               nodeID,
 		PluginName:           *pluginNameFlag,
 		WorkloadAPISocketDir: *workloadAPISocketDirFlag,
+		RecursiveBind:        *recursiveBindFlag,
 	})
 	if err != nil {
 		log.Error(err, "Failed to create driver")

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -18,9 +18,11 @@ import (
 
 var (
 	// We replace these in tests since bind mounting generally requires root.
-	bindMountRW  = mount.BindMountRW
-	unmount      = mount.Unmount
-	isMountPoint = mount.IsMountPoint
+	bindMountRW          = mount.BindMountRW
+	bindMountRecursiveRW = mount.BindMountRecursiveRW
+	unmount              = mount.Unmount
+	unmountDetach        = mount.UnmountDetach
+	isMountPoint         = mount.IsMountPoint
 )
 
 // Config is the configuration for the driver
@@ -29,6 +31,18 @@ type Config struct {
 	NodeID               string
 	PluginName           string
 	WorkloadAPISocketDir string
+
+	// RecursiveBind publishes anything mounted beneath the Workload API socket
+	// directory along with the directory itself, and keeps tracking it as it is
+	// mounted and unmounted. Off by default, since it changes what a workload
+	// sees and how the volume is torn down.
+	//
+	// It is needed when the socket directory is not a plain directory holding a
+	// socket but a mount point in its own right, or contains one: with a plain
+	// bind a workload sees the underlying directory and never the filesystem
+	// mounted on it, and a filesystem replaced while the workload is running is
+	// never picked up.
+	RecursiveBind bool
 }
 
 // Driver is the ephemeral-inline CSI driver implementation
@@ -40,6 +54,7 @@ type Driver struct {
 	nodeID               string
 	pluginName           string
 	workloadAPISocketDir string
+	recursiveBind        bool
 }
 
 // New creates a new driver with the given config
@@ -55,6 +70,7 @@ func New(config Config) (*Driver, error) {
 		nodeID:               config.NodeID,
 		pluginName:           config.PluginName,
 		workloadAPISocketDir: config.WorkloadAPISocketDir,
+		recursiveBind:        config.RecursiveBind,
 	}, nil
 }
 
@@ -143,7 +159,11 @@ func (d *Driver) NodePublishVolume(_ context.Context, req *csi.NodePublishVolume
 	// be writable by workload containers. We enforce that the CSI volume is
 	// marked read-only above, instructing the kubelet to mount it read-only
 	// into containers, while we mount the volume read-write to the host.
-	if err := bindMountRW(d.workloadAPISocketDir, req.TargetPath); err != nil {
+	bindMount := bindMountRW
+	if d.recursiveBind {
+		bindMount = bindMountRecursiveRW
+	}
+	if err := bindMount(d.workloadAPISocketDir, req.TargetPath); err != nil {
 		return nil, status.Errorf(codes.Internal, "unable to mount %q: %v", req.TargetPath, err)
 	}
 
@@ -177,7 +197,13 @@ func (d *Driver) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpublishVo
 	if ok, err := isMountPoint(req.TargetPath); err != nil {
 		return nil, status.Errorf(codes.Internal, "unable to verify mount point %q: %v", req.TargetPath, err)
 	} else if ok {
-		if err := unmount(req.TargetPath); err != nil {
+		// A recursive bind can leave the target with child mounts, which a
+		// plain unmount refuses with EBUSY, so the two settings move together.
+		unmountTarget := unmount
+		if d.recursiveBind {
+			unmountTarget = unmountDetach
+		}
+		if err := unmountTarget(req.TargetPath); err != nil {
 			return nil, status.Errorf(codes.Internal, "unable to unmount %q: %v", req.TargetPath, err)
 		}
 	}

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -569,3 +569,66 @@ func assertProtoEqual[M proto.Message](t *testing.T, a, b M) {
 		require.FailNowf(t, "Proto are not equal", "diff:\n%s\n", diff)
 	}
 }
+
+// The recursive bind and the detaching unmount are one setting, not two: a
+// recursive bind can leave the target with child mounts, and unmounting a mount
+// that has children fails with EBUSY. Assert that each setting picks the pair
+// that goes together, since getting one without the other wedges teardown.
+func TestRecursiveBindSelectsMatchingMountAndUnmount(t *testing.T) {
+	for _, tt := range []struct {
+		desc          string
+		recursiveBind bool
+		wantBind      string
+		wantUnmount   string
+	}{
+		{desc: "off by default", recursiveBind: false, wantBind: "plain", wantUnmount: "plain"},
+		{desc: "on", recursiveBind: true, wantBind: "recursive", wantUnmount: "detach"},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			var gotBind, gotUnmount string
+
+			restore := func(b, br func(string, string) error, u, ud func(string) error) func() {
+				return func() { bindMountRW, bindMountRecursiveRW, unmount, unmountDetach = b, br, u, ud }
+			}(bindMountRW, bindMountRecursiveRW, unmount, unmountDetach)
+			t.Cleanup(restore)
+
+			bindMountRW = func(src, dst string) error { gotBind = "plain"; return writeMeta(dst, src) }
+			bindMountRecursiveRW = func(src, dst string) error { gotBind = "recursive"; return writeMeta(dst, src) }
+			unmount = func(dst string) error { gotUnmount = "plain"; return os.Remove(metaPath(dst)) }
+			unmountDetach = func(dst string) error { gotUnmount = "detach"; return os.Remove(metaPath(dst)) }
+
+			d, err := New(Config{
+				Log:                  logr.Discard(),
+				NodeID:               testNodeID,
+				PluginName:           "csi.spiffe.io",
+				WorkloadAPISocketDir: t.TempDir(),
+				RecursiveBind:        tt.recursiveBind,
+			})
+			require.NoError(t, err)
+
+			targetPath := filepath.Join(t.TempDir(), "target")
+			_, err = d.NodePublishVolume(context.Background(), &csi.NodePublishVolumeRequest{
+				VolumeId:   "volumeID",
+				TargetPath: targetPath,
+				// Set explicitly: this call does not go through gRPC, so
+				// nothing materialises the inner message the way a round trip
+				// through protobuf does for the other tests.
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{}},
+					AccessMode: &csi.VolumeCapability_AccessMode{},
+				},
+				Readonly:      true,
+				VolumeContext: map[string]string{"csi.storage.k8s.io/ephemeral": "true"},
+			})
+			require.NoError(t, err)
+			require.Equal(t, tt.wantBind, gotBind, "wrong bind mount for recursiveBind=%v", tt.recursiveBind)
+
+			_, err = d.NodeUnpublishVolume(context.Background(), &csi.NodeUnpublishVolumeRequest{
+				VolumeId:   "volumeID",
+				TargetPath: targetPath,
+			})
+			require.NoError(t, err)
+			require.Equal(t, tt.wantUnmount, gotUnmount, "wrong unmount for recursiveBind=%v", tt.recursiveBind)
+		})
+	}
+}

--- a/pkg/logkeys/keys.go
+++ b/pkg/logkeys/keys.go
@@ -6,6 +6,7 @@ const (
 	CSISocketPath        = "csiSocketPath"
 	FullMethod           = "fullMethod"
 	NodeID               = "nodeID"
+	RecursiveBind        = "recursiveBind"
 	TargetPath           = "targetPath"
 	Version              = "version"
 	VolumeID             = "volumeID"

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -6,9 +6,25 @@ func BindMountRW(root, mountPoint string) error {
 	return bindMountRW(root, mountPoint)
 }
 
+// BindMountRecursiveRW performs a read-write bind mount from root to mountPoint,
+// including anything mounted beneath root. Mounts made under root afterwards
+// propagate to mountPoint when root is on a shared mount.
+//
+// UnmountDetach must be used to undo it; see that function.
+func BindMountRecursiveRW(root, mountPoint string) error {
+	return bindMountRecursiveRW(root, mountPoint)
+}
+
 // Unmount unmounts a mount
 func Unmount(mountPoint string) error {
 	return unmount(mountPoint)
+}
+
+// UnmountDetach detaches a mount and anything mounted beneath it. It is the
+// counterpart of BindMountRecursiveRW: a recursive bind can leave the mount with
+// children, and unmounting a mount that has children fails with EBUSY.
+func UnmountDetach(mountPoint string) error {
+	return unmountDetach(mountPoint)
 }
 
 // IsMountPoint returns whether or not the given mount point is valid.

--- a/pkg/mount/mount_linux.go
+++ b/pkg/mount/mount_linux.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	msBind uintptr = 4096 // LINUX MS_BIND
+	msBind uintptr = 4096  // LINUX MS_BIND
+	msRec  uintptr = 16384 // LINUX MS_REC
 )
 
 var (
@@ -31,8 +32,23 @@ func bindMountRW(root, mountPoint string) error {
 	return unix.Mount(root, mountPoint, "none", msBind, "")
 }
 
+// bindMountRecursiveRW binds root to mountPoint along with anything mounted
+// beneath it. A plain bind copies only the directory, so a filesystem already
+// mounted under root at the time of the bind is not carried across, and one
+// mounted afterwards never appears.
+func bindMountRecursiveRW(root, mountPoint string) error {
+	return unix.Mount(root, mountPoint, "none", msBind|msRec, "")
+}
+
 func unmount(mountPoint string) error {
 	return unix.Unmount(mountPoint, 0)
+}
+
+// unmountDetach detaches mountPoint and anything mounted beneath it. A plain
+// unmount of a mount that has children fails with EBUSY, which is why this is
+// the counterpart of bindMountRecursiveRW rather than an independent choice.
+func unmountDetach(mountPoint string) error {
+	return unix.Unmount(mountPoint, unix.MNT_DETACH)
 }
 
 func isMountPoint(mountPoint string) (bool, error) {

--- a/pkg/mount/mount_other.go
+++ b/pkg/mount/mount_other.go
@@ -11,7 +11,15 @@ func bindMountRW(string, string) error {
 	return errors.New("unsupported on this platform")
 }
 
+func bindMountRecursiveRW(string, string) error {
+	return errors.New("unsupported on this platform")
+}
+
 func unmount(string) error {
+	return errors.New("unsupported on this platform")
+}
+
+func unmountDetach(string) error {
 	return errors.New("unsupported on this platform")
 }
 


### PR DESCRIPTION
SPIFFEFS is fused based, which means it runs in userspace. if it ever crashes or is intentionally restarted, the kernel marks all syscalls to the mount to fail. you can overmount it on the host, but k8s's submounts hold onto it. So, we put SPIFFEFS under a subdir of the volume. This allows it to mount/remount and show up in the containers. This only works though if recursive mount propagation is enabled on the mount.
